### PR TITLE
Increase salt size

### DIFF
--- a/src/engine.cr
+++ b/src/engine.cr
@@ -19,7 +19,7 @@ module Scrypt
     end
 
     def self.generate_salt(salt_size = DEFAULT_SALT_SIZE)
-      Random::Secure.hex(salt_size // 2)
+      Random::Secure.hex(salt_size)
     end
 
     def self.crypto_scrypt(secret, salt, n, r, p, key_len)

--- a/test/scrypt_test.cr
+++ b/test/scrypt_test.cr
@@ -27,12 +27,12 @@ class Scrypt::PasswordTest < Minitest::Test
 
   def test_create
     pw = Password.create("secret", key_len: 32, salt_size: 8)
-    assert_match(/\A[a-f0-9]+\$[a-f0-9]+\$[a-f0-9]+\$[a-f0-9]{8}\$[a-z0-9]{64}\Z/, pw.to_s)
+    assert_match(/\A[a-f0-9]+\$[a-f0-9]+\$[a-f0-9]+\$[a-f0-9]{16}\$[a-z0-9]{64}\Z/, pw.to_s)
     assert pw.verify "secret"
     refute pw.verify "guessy"
 
     pw = Password.create("super secret message", key_len: 64, salt_size: 32)
-    assert_match(/\A[a-f0-9]+\$[a-f0-9]+\$[a-f0-9]+\$[a-f0-9]{32}\$[a-z0-9]{128}\Z/, pw.to_s)
+    assert_match(/\A[a-f0-9]+\$[a-f0-9]+\$[a-f0-9]+\$[a-f0-9]{64}\$[a-z0-9]{128}\Z/, pw.to_s)
     assert pw.verify "super secret message"
     refute pw.verify "super wrong message"
   end
@@ -51,9 +51,9 @@ class Scrypt::PasswordTest < Minitest::Test
 
   def test_clamps_salt_size
     pw = Password.create("secret", salt_size: 1)
-    assert_equal 8, pw.salt.size
+    assert_equal 16, pw.salt.size
 
     pw = Password.create("secret", salt_size: 128)
-    assert_equal 32, pw.salt.size
+    assert_equal 64, pw.salt.size
   end
 end


### PR DESCRIPTION
Solves #8.

Min salt size is increased from 4 to 8 bytes (64 bits) and also the maximum size is increased from 16 to 32 bytes (256 bits) for security reasons. Maybe that will be needed somebody. _(I only saw the "recommendation" to use 128 bits salt but not a restriction. If needed, i'll reduce it.)_

All tests work.